### PR TITLE
Put mail addresses in parentheses

### DIFF
--- a/t/003_basic.t
+++ b/t/003_basic.t
@@ -144,7 +144,7 @@ $c1->supports_unlike('SIZE', qr/9999/, 'Passes if size does not contain 9999');
 $c1->supports_cmp_ok('SIZE', '==', 1000, 'Passes if SIZE == 1000');
 $c1->supports_cmp_ok('SIZE', '!=', 9999, 'Passes if SIZE != 9999');
 
-$c1->mail_from_ko('temporary-450@failure.com', 'Passes if the mail_from fails');
+$c1->mail_from_ko('<temporary-450@failure.com>', 'Passes if the mail_from fails');
 $c1->code_is(450, 'Passes if temporary failure with code 450');
 $c1->code_isnt(444, 'Passes if temporary failure is not with code 444');
 $c1->message_like(qr/temporary failure for temporary-450\@failure.com/, 'Passes if expected message matches');
@@ -154,7 +154,7 @@ $c1->code_is_failure('Passes if code indicated some type of failure');
 $c1->code_isnt_success('Passes if code did not indicate success');
 $c1->code_isnt_permanent('Passes if code did not indicate permanent failure');
 
-$c1->mail_from_ko('permanent-550@failure.com', 'Passes if the mail_from fails');
+$c1->mail_from_ko('<permanent-550@failure.com>', 'Passes if the mail_from fails');
 $c1->code_is(550, 'Passes if temporary failure with code 550');
 $c1->code_isnt(555, 'Passes if temporary failure is not with code 555');
 $c1->message_like(qr/temporary failure for permanent-550\@failure.com/, 'Passes if expected message matches');
@@ -164,7 +164,7 @@ $c1->code_is_failure('Passes if code indicated some type of failure');
 $c1->code_isnt_success('Passes if code did not indicate success');
 $c1->code_is_permanent('Passes if code indicated temporary failure');
 
-$c1->mail_from_ok('success-220@success.com', 'Passes if the mail_from is ok');
+$c1->mail_from_ok('<success-220@success.com>', 'Passes if the mail_from is ok');
 $c1->code_is(220, 'Passes if code 220');
 $c1->code_isnt(222, 'Passes if is not with code 222');
 $c1->message_like(qr/success for success-220\@success.com/, 'Passes if expected message matches');
@@ -178,7 +178,7 @@ $c1->code_isnt_permanent('Passes if code did not indicate pemanent failure');
 # RCPT TO TESTS
 # 
 
-$c1->rcpt_to_ko('temporary-450@failure.com', 'Passes if the mail_from fails');
+$c1->rcpt_to_ko('<temporary-450@failure.com>', 'Passes if the mail_from fails');
 $c1->code_is(450, 'Passes if temporary failure with code 450');
 $c1->code_isnt(444, 'Passes if temporary failure is not with code 444');
 $c1->message_like(qr/temporary failure for temporary-450\@failure.com/, 'Passes if expected message matches');
@@ -188,7 +188,7 @@ $c1->code_is_failure('Passes if code indicated some type of failure');
 $c1->code_isnt_success('Passes if code did not indicate success');
 $c1->code_isnt_permanent('Passes if code did not indicate permanent failure');
 
-$c1->rcpt_to_ko('permanent-550@failure.com', 'Passes if the mail_from fails');
+$c1->rcpt_to_ko('<permanent-550@failure.com>', 'Passes if the mail_from fails');
 $c1->code_is(550, 'Passes if temporary failure with code 550');
 $c1->code_isnt(555, 'Passes if temporary failure is not with code 555');
 $c1->message_like(qr/temporary failure for permanent-550\@failure.com/, 'Passes if expected message matches');
@@ -199,7 +199,7 @@ $c1->code_isnt_success('Passes if code did not indicate success');
 $c1->code_is_permanent('Passes if code did indicated permanent failure');
 
 
-$c1->rcpt_to_ok('success-220@success.com', 'Passes if the mail_from is ok');
+$c1->rcpt_to_ok('<success-220@success.com>', 'Passes if the mail_from is ok');
 $c1->code_is(220, 'Passes if code 220');
 $c1->code_isnt(222, 'Passes if is not with code 222');
 $c1->message_like(qr/success for success-220\@success.com/, 'Passes if expected message matches');
@@ -224,8 +224,8 @@ $c1->rset_ok('Passes if RSET accepted');
 
 $c1->hello('mydomain.com');
 
-$c1->mail_from_ok('success-220@success.com');
-$c1->rcpt_to_ok('success-220@success.com');
+$c1->mail_from_ok('<success-220@success.com>');
+$c1->rcpt_to_ok('<success-220@success.com>');
 $c1->data_ok('Passes if data was succesful');
 $c1->datasend([
     "DO NOT ACCEPT THIS MESSAGE\n",

--- a/t/005_fail_tests.t
+++ b/t/005_fail_tests.t
@@ -131,14 +131,14 @@ test_out('not ok 3 - Fails if server announces PIPELINING');
 test_fail(+1);
 $c1->supports_ko('PIPELINING', 'Fails if server announces PIPELINING');
 test_out('not ok 4 - Fails if the mail_from fails');
-$c1->mail_from_ok('temporary-450@failure.com', 'Fails if the mail_from fails');
+$c1->mail_from_ok('<temporary-450@failure.com>', 'Fails if the mail_from fails');
 test_fail(+1);
 test_out('not ok 5 - Fails if the mail_from fails');
 test_fail(+1);
-$c1->mail_from_ok('permanent-550@failure.com', 'Fails if the mail_from fails');
+$c1->mail_from_ok('<permanent-550@failure.com>', 'Fails if the mail_from fails');
 test_out('not ok 6 - Fails if the mail_from is ok');
 test_fail(+1);
-$c1->mail_from_ko('success-220@success.com', 'Fails if the mail_from is ok');
+$c1->mail_from_ko('<success-220@success.com>', 'Fails if the mail_from is ok');
 
 #
 # RCPT TO TESTS
@@ -146,7 +146,7 @@ $c1->mail_from_ko('success-220@success.com', 'Fails if the mail_from is ok');
 
 test_out('not ok 7 - Fails if the mail_from fails');
 test_fail(+1);
-$c1->rcpt_to_ok('temporary-450@failure.com', 'Fails if the mail_from fails');
+$c1->rcpt_to_ok('<temporary-450@failure.com>', 'Fails if the mail_from fails');
 test_out('not ok 8 - Fails because last code was temporary');
 test_fail(+1);
 $c1->code_isnt_temporary('Fails because last code was temporary');
@@ -164,7 +164,7 @@ $c1->code_isnt_failure('Fails because last code was temporary');
 
 test_out('not ok 12 - Fails if the mail_from fails');
 test_fail(+1);
-$c1->rcpt_to_ok('permanent-550@failure.com', 'Fails if the mail_from fails');
+$c1->rcpt_to_ok('<permanent-550@failure.com>', 'Fails if the mail_from fails');
 test_out('not ok 13 - Fails because last code was permanent');
 test_fail(+1);
 $c1->code_is_temporary('Fails because last code was permanent');
@@ -181,7 +181,7 @@ $c1->code_isnt_failure('Fails because last code was permanent');
 
 test_out('not ok 17 - Fails if the mail_from is ok');
 test_fail(+1);
-$c1->rcpt_to_ko('success-220@success.com', 'Fails if the mail_from is ok');
+$c1->rcpt_to_ko('<success-220@success.com>', 'Fails if the mail_from is ok');
 
 test_out('not ok 18 - Fails because last code was success');
 test_fail(+1);
@@ -235,8 +235,8 @@ my $c2 = Test::SMTP->connect_ko("connects to SMTP on $LOCAL_PORT",
                                 AutoHello => 1,
                                 ); 
 
-$c2->mail_from('success-220@success.com');
-$c2->rcpt_to('success-220@success.com');
+$c2->mail_from('<success-220@success.com>');
+$c2->rcpt_to('<success-220@success.com>');
 
 $c2->data;
 $c2->datasend([ "DO NOT ACCEPT THIS MESSAGE\n", "L2\n" ]);


### PR DESCRIPTION
Net::Server::Mail >= 0.18 requires that mail addresses use parentheses.

This adds < > around all mail addresses in tests.

fixes cpanrt #109038
